### PR TITLE
Allow other methods in CommandListeners

### DIFF
--- a/src/main/java/com/not2excel/api/command/CommandManager.java
+++ b/src/main/java/com/not2excel/api/command/CommandManager.java
@@ -324,7 +324,7 @@ public class CommandManager
 			if (commandHandler == null
 					|| method.getParameterTypes()[0] != CommandInfo.class)
 			{
-				return;
+				break;
 			}
 			logger.log("Method: " + method.getName() + " is a CommandHandler");
 			Object object = classObject;


### PR DESCRIPTION
This commit allows methods to be in CommandListeners that aren't necessarily commands. It also fixes the bug where if you do have a method that isn't a command, the commands that come after it are not registered.
