### PR TITLE
Added ability to mark methods as only usable by players

### DIFF
--- a/src/main/java/com/not2excel/api/command/CommandHandler.java
+++ b/src/main/java/com/not2excel/api/command/CommandHandler.java
@@ -6,7 +6,7 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * @author Richmond Steele
+ * @author Richmond Steele, William Reed
  * @since 12/16/13
  * All rights Reserved
  * Please read included LICENSE file
@@ -78,4 +78,10 @@ public @interface CommandHandler
      * @return max
      */
     int max() default -1;
+    
+    /**
+     * Determines if you want the plugin to be only executed by a player and not on command line
+     * @return true if you want this only to be used by an in game player
+     */
+    boolean playerOnly() default false;
 }

--- a/src/main/java/com/not2excel/api/command/handler/DefaultHandler.java
+++ b/src/main/java/com/not2excel/api/command/handler/DefaultHandler.java
@@ -1,5 +1,6 @@
 package com.not2excel.api.command.handler;
 
+import com.not2excel.api.command.CommandHandler;
 import com.not2excel.api.command.objects.ChildCommand;
 import com.not2excel.api.command.objects.CommandInfo;
 import com.not2excel.api.command.objects.ParentCommand;
@@ -11,7 +12,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 
 /**
- * @author Richmond Steele
+ * @author Richmond Steele, William Reed
  * @since 12/18/13
  * All rights Reserved
  * Please read included LICENSE file
@@ -104,34 +105,43 @@ public class DefaultHandler implements Handler
     
     private void sendCommand(CommandInfo info) throws CommandException
     {
+    	CommandHandler ch = queue.getMethod().getAnnotation(CommandHandler.class);
+    	boolean playerOnly = ch.playerOnly();
+    	
         if (info.getArgsLength() < info.getCommandHandler().min())
-                {
-                    info.getSender().sendMessage("Too few arguments.");
-                    info.getRegisteredCommand().displayDefaultUsage(info.getSender(), info.getCommand(), info.getParentCommand());
-                    throw new CommandException("Too few arguments.");
-                }
-                if (info.getCommandHandler().max() != -1 && info.getArgsLength() > info.getCommandHandler().max())
-                {
-                    info.getSender().sendMessage("Too many arguments.");
-                    info.getRegisteredCommand().displayDefaultUsage(info.getSender(), info.getCommand(), info.getParentCommand());
-                    throw new CommandException("Too many arguments.");
-                }
-                if (!info.getSender().hasPermission(info.getCommandHandler().permission()))
-                {
-                    Colorizer.send(info.getSender(), "<red>" + info.getCommandHandler().noPermission());
-                    return;
-                }
-                try
-                {
-                    queue.getMethod().invoke(queue.getObject(), info);
-                }
-                catch (IllegalAccessException e)
-                {
-                    e.printStackTrace();
-                }
-                catch (InvocationTargetException e)
-                {
-                    e.printStackTrace();
-                }
+        {
+            info.getSender().sendMessage("Too few arguments.");
+            info.getRegisteredCommand().displayDefaultUsage(info.getSender(), info.getCommand(), info.getParentCommand());
+            throw new CommandException("Too few arguments.");
+        }
+        if (info.getCommandHandler().max() != -1 && info.getArgsLength() > info.getCommandHandler().max())
+        {
+            info.getSender().sendMessage("Too many arguments.");
+            info.getRegisteredCommand().displayDefaultUsage(info.getSender(), info.getCommand(), info.getParentCommand());
+            throw new CommandException("Too many arguments.");
+        }
+        if (!info.getSender().hasPermission(info.getCommandHandler().permission()))
+        {
+            Colorizer.send(info.getSender(), "<red>" + info.getCommandHandler().noPermission());
+            return;
+        }
+        if(playerOnly && !info.isPlayer())
+        {
+      	//maybe make this configurable some how
+        	info.getSender().sendMessage("This command can only be executed in game.");
+            return;
+        }
+        try
+        {
+            queue.getMethod().invoke(queue.getObject(), info);
+        }
+            catch (IllegalAccessException e)
+        {
+            e.printStackTrace();
+        }
+            catch (InvocationTargetException e)
+        {
+            e.printStackTrace();
+        }
     }
 }

--- a/src/main/java/com/not2excel/api/command/handler/DefaultHandler.java
+++ b/src/main/java/com/not2excel/api/command/handler/DefaultHandler.java
@@ -127,9 +127,9 @@ public class DefaultHandler implements Handler
         }
         if(playerOnly && !info.isPlayer())
         {
-      	//maybe make this configurable some how
-        	info.getSender().sendMessage("This command can only be executed in game.");
-            return;
+             //maybe make this configurable some how
+             info.getSender().sendMessage("This command can only be executed in game.");
+             return;
         }
         try
         {


### PR DESCRIPTION
A little bit of code to make it easier for programmers to mark methods so that they are only usable by players. For example a teleport method would not make sense to be used by command line so a developer would likely want to mark the method with this.
Example:

``` java
    @CommandHandler
    (
            command = "teleport", 
            permission = "essentials.teleport", 
            noPermission = "You do not have permission to teleport",
            usage = "/teleport <person to teleport to>",
            playerOnly = true
    )
    public void onCommandUpgrade(CommandInfo info) 
    {
            //teleport player here
            //this code is only reachable if a player calls the command
            //and not if someone on command line calls it

    }
```
